### PR TITLE
Enhance Blade class modifier transformation to support hyphenated modifiers and prevent false positives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,31 @@ composer require useclassy/laravel
 
 The service provider will be automatically registered via Laravel's package auto-discovery.
 
+### Vite + Tailwind companion
+
+This package rewrites Blade at compile time. For Tailwind JIT to discover the generated variant classes, also install [`vite-plugin-useclassy`](https://www.npmjs.com/package/vite-plugin-useclassy) in your app and set `language: "blade"`:
+
+```ts
+// vite.config.ts
+import useClassy from "vite-plugin-useclassy";
+
+export default {
+  plugins: [
+    useClassy({
+      language: "blade",
+    }),
+    // ... other plugins
+  ],
+};
+```
+
+Point Tailwind at the plugin manifest (default `.classy/output.classy.html`):
+
+- **Tailwind v4** — in your CSS entry: `@source "./.classy/output.classy.html";` (path relative to that CSS file)
+- **Tailwind v3** — add `"./.classy/output.classy.html"` to the `content` array in `tailwind.config.*`
+
+Or run `npx vite-plugin-useclassy init --language blade` from your app root to patch Vite, Tailwind, and editor settings when possible.
+
 ## Usage
 
 Use the `class:modifier` syntax in your Blade templates:
@@ -19,8 +44,8 @@ Use the `class:modifier` syntax in your Blade templates:
     Responsive heading that changes on large screens and hover
 </h1>
 
-<div class:dark="bg-gray-800 text-white" class:lg="p-6">
-    Dark mode and responsive padding
+<div class:dark="bg-gray-800 text-white" class:lg="p-6" class:group-hover="opacity-100">
+    Dark mode, responsive padding, and group hover
 </div>
 ```
 
@@ -29,6 +54,7 @@ The package will automatically transform these during Blade compilation:
 - `class:lg="text-3xl"` becomes `lg:text-3xl`
 - `class:hover="text-blue-600"` becomes `hover:text-blue-600`
 - `class:dark="bg-gray-800 text-white"` becomes `dark:bg-gray-800 dark:text-white`
+- `class:group-hover="opacity-100"` becomes `group-hover:opacity-100`
 
 These transformed classes are merged with any existing `class` attributes.
 

--- a/src/BladeClassModifierTransformer.php
+++ b/src/BladeClassModifierTransformer.php
@@ -17,7 +17,9 @@ final class BladeClassModifierTransformer
 
     public function transform(string $value): string
     {
-        $pattern = '/\bclass:([\w:]+)=(["\'`])([^"\'`]*)\2/';
+        // Parity with vite-plugin-useclassy: lookbehind avoids :class / someclass false
+        // positives; [\w:-]+ allows hyphenated modifiers (group-hover, focus-within, etc.).
+        $pattern = '/(?<![:\w])class:([\w:-]+)=(["\'`])([^"\'`]*)\2/';
 
         $value = preg_replace_callback($pattern, function (array $matches): string {
             $modifier = $matches[1];

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,14 @@
+# Sync useclassy/laravel with vite-plugin-useclassy 3.x
+
+- [x] Update BladeClassModifierTransformer regex: lookbehind + hyphens
+- [x] Add tests for group-hover/focus-within and false-positive guards
+- [x] Document Vite blade language + Tailwind manifest companion setup
+- [x] Run PHPUnit to confirm parity tests and existing suite pass
+
+## Review
+
+- Regex in `BladeClassModifierTransformer` now matches Vite 3.x: `(?<![:\w])class:([\w:-]+)=...`
+- Hyphenated modifiers (`group-hover`, `focus-within`, `peer-focus`) transform correctly
+- False positives (`someclass:hover`, `:class:hover`) left untouched
+- README documents Vite `language: "blade"` + Tailwind `@source` / `content` companion setup
+- PHPUnit: 23 tests, 41 assertions, OK

--- a/tests/UseClassyServiceProviderTest.php
+++ b/tests/UseClassyServiceProviderTest.php
@@ -206,4 +206,42 @@ class UseClassyServiceProviderTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function test_transform_hyphenated_modifiers(): void
+    {
+        $t = $this->transformer();
+
+        $this->assertEquals(
+            '<div class="group-hover:bg-blue-100">Content</div>',
+            $t->transform('<div class:group-hover="bg-blue-100">Content</div>')
+        );
+
+        $this->assertEquals(
+            '<div class="focus-within:ring-2">Content</div>',
+            $t->transform('<div class:focus-within="ring-2">Content</div>')
+        );
+
+        $this->assertEquals(
+            '<div class="peer-focus:opacity-100">Content</div>',
+            $t->transform('<div class:peer-focus="opacity-100">Content</div>')
+        );
+    }
+
+    public function test_transform_does_not_match_class_substring_in_larger_word(): void
+    {
+        $input = '<div someclass:hover="text-blue-500">Content</div>';
+
+        $result = $this->transformer()->transform($input);
+
+        $this->assertEquals($input, $result);
+    }
+
+    public function test_transform_does_not_match_colon_prefixed_class_hover(): void
+    {
+        $input = '<div :class:hover="text-blue-500">Content</div>';
+
+        $result = $this->transformer()->transform($input);
+
+        $this->assertEquals($input, $result);
+    }
 }


### PR DESCRIPTION
This pull request updates the package to maintain parity with `vite-plugin-useclassy` 3.x, improving support for hyphenated Tailwind modifiers and preventing false positives during Blade compilation. It also adds comprehensive documentation for integrating with Vite and Tailwind, and introduces new tests to ensure correct behavior.

### Blade transformation improvements
* Updated the regex in `BladeClassModifierTransformer` to support hyphenated modifiers (e.g., `group-hover`, `focus-within`) and prevent matching similar substrings in other attribute names, ensuring accurate transformation of class modifiers.
* Added tests in `UseClassyServiceProviderTest.php` for hyphenated modifiers and false-positive cases, confirming that only valid `class:modifier` patterns are transformed.

### Documentation updates
* Updated `README.md` to document Vite + Tailwind companion setup, including usage of `vite-plugin-useclassy` with `language: "blade"` and Tailwind configuration for the plugin manifest.
* Expanded usage examples and transformation descriptions in `README.md` to include hyphenated modifiers like `group-hover`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57)

### Project management
* Added a checklist and review notes to `tasks/todo.md` to track and confirm parity with `vite-plugin-useclassy` 3.x, including regex changes, test coverage, documentation, and test suite results.